### PR TITLE
CDAP-15823 Elasticsearch-plugins plugin validation - package rename 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.cdap.plugins</groupId>
   <artifactId>elasticsearch-plugins</artifactId>
-  <version>1.10.0</version>
+  <version>1.10.0-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -80,10 +80,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <junit.version>4.11</junit.version>
-    <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
+    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
     <es.version>5.4.0</es.version>
     <es-hadoop.version>5.4.0</es-hadoop.version>
     <slf4j.version>1.7.5</slf4j.version>
@@ -96,8 +96,6 @@
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
-
-
 
   <dependencies>
     <dependency>
@@ -326,9 +324,10 @@
           <extensions>true</extensions>
           <configuration>
             <instructions>
-              <_exportcontents>io.cdap.plugin.batch.*;org.elasticsearch.hadoop.mr.*;
-                org.apache.commons.lang;org.apache.commons.*;org.apache.commons.logging.*;
-                org.codehaus.jackson.*;io.netty.*</_exportcontents>
+              <_exportcontents>
+                io.cdap.plugin.elastic.*;
+                org.elasticsearch.hadoop.mr.*;
+              </_exportcontents>
               <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
               <Embed-Transitive>true</Embed-Transitive>
               <Embed-Directory>lib</Embed-Directory>
@@ -349,8 +348,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[5.0.0,6.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[5.0.0,6.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>

--- a/src/main/java/io/cdap/plugin/elastic/ESProperties.java
+++ b/src/main/java/io/cdap/plugin/elastic/ESProperties.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch;
+package io.cdap.plugin.elastic;
 
 /**
  * Constants for ElasticSearch plugins.

--- a/src/main/java/io/cdap/plugin/elastic/RecordWritableConverter.java
+++ b/src/main/java/io/cdap/plugin/elastic/RecordWritableConverter.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch;
+package io.cdap.plugin.elastic;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;

--- a/src/main/java/io/cdap/plugin/elastic/sink/BatchElasticsearchSink.java
+++ b/src/main/java/io/cdap/plugin/elastic/sink/BatchElasticsearchSink.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch.sink;
+package io.cdap.plugin.elastic.sink;
 
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -27,11 +27,12 @@ import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
-import io.cdap.plugin.batch.ESProperties;
+
 import io.cdap.plugin.common.ReferenceBatchSink;
 import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.common.batch.JobUtils;
 import io.cdap.plugin.common.batch.sink.SinkOutputFormatProvider;
+import io.cdap.plugin.elastic.ESProperties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;

--- a/src/main/java/io/cdap/plugin/elastic/source/ElasticsearchSource.java
+++ b/src/main/java/io/cdap/plugin/elastic/source/ElasticsearchSource.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch.source;
+package io.cdap.plugin.elastic.source;
 
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -29,12 +29,12 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
-import io.cdap.plugin.batch.ESProperties;
-import io.cdap.plugin.batch.RecordWritableConverter;
 import io.cdap.plugin.common.ReferenceBatchSource;
 import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.common.SourceInputFormatProvider;
 import io.cdap.plugin.common.batch.JobUtils;
+import io.cdap.plugin.elastic.ESProperties;
+import io.cdap.plugin.elastic.RecordWritableConverter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.Text;

--- a/src/test/java/io/cdap/plugin/elastic/RecordWritableConverterTest.java
+++ b/src/test/java/io/cdap/plugin/elastic/RecordWritableConverterTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch;
+package io.cdap.plugin.elastic;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15823
In scope of this PR:

- migrated to CDAP core 6.1.0-SNAPSHOT
- renamed packages to io.cdap.plugin.elastic
- removed unnecessary exports