### PR TITLE
PLUGIN-682 Copied EsInputFormat and EsOutputFormat classes from OSS a…

### DIFF
--- a/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
+++ b/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.mr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.MapWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.Progressable;
+import org.elasticsearch.hadoop.cfg.HadoopSettings;
+import org.elasticsearch.hadoop.cfg.HadoopSettingsManager;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.rest.InitializationUtils;
+import org.elasticsearch.hadoop.rest.PartitionDefinition;
+import org.elasticsearch.hadoop.rest.RestRepository;
+import org.elasticsearch.hadoop.rest.RestService;
+import org.elasticsearch.hadoop.rest.RestService.PartitionReader;
+import org.elasticsearch.hadoop.rest.ScrollQuery;
+import org.elasticsearch.hadoop.rest.SearchRequestBuilder;
+import org.elasticsearch.hadoop.rest.stats.Stats;
+import org.elasticsearch.hadoop.serialization.ScrollReader;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ElasticSearch {@link InputFormat} for streaming data (typically based on a query) from ElasticSearch.
+ * Returns the document ID as key and its content as value.
+ *
+ * <p/>This class implements both the "old" (<tt>org.apache.hadoop.mapred</tt>) and the
+ * "new" (<tt>org.apache.hadoop.mapreduce</tt>) API.
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ */
+public class EsInputFormat<K, V> extends InputFormat<K, V> implements org.apache.hadoop.mapred.InputFormat<K, V> {
+
+  private static Log log = LogFactory.getLog(EsInputFormat.class);
+
+  /**
+   * Input Split
+   */
+  protected static class EsInputSplit extends InputSplit implements org.apache.hadoop.mapred.InputSplit {
+    private PartitionDefinition partition;
+
+    public EsInputSplit() {}
+
+    public EsInputSplit(PartitionDefinition partition) {
+      this.partition = partition;
+    }
+
+    @Override
+    public long getLength() {
+      // TODO: can this be computed easily?
+      return 1L;
+    }
+
+    @Override
+    public String[] getLocations() {
+      return partition.getHostNames();
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+      partition.write(out);
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+      partition = new PartitionDefinition(in);
+    }
+
+    public PartitionDefinition getPartition() {
+      return partition;
+    }
+  }
+
+  /**
+   *
+   * @param <K>
+   * @param <V>
+   */
+  protected abstract static class EsInputRecordReader<K, V>
+    extends RecordReader<K, V> implements org.apache.hadoop.mapred.RecordReader<K, V> {
+
+    private int read = 0;
+    private EsInputSplit esSplit;
+    private ScrollReader scrollReader;
+
+    private RestRepository client;
+    private SearchRequestBuilder queryBuilder;
+    private ScrollQuery scrollQuery;
+
+    // reuse objects
+    private K currentKey;
+    private V currentValue;
+
+    private long size = 0;
+
+    private HeartBeat beat;
+    private Progressable progressable;
+
+    // default constructor used by the NEW api
+    public EsInputRecordReader() {
+    }
+
+    // constructor used by the old API
+    public EsInputRecordReader(org.apache.hadoop.mapred.InputSplit split, Configuration job, Reporter reporter) {
+      reporter.setStatus(split.toString());
+      init((EsInputSplit) split, job, reporter);
+    }
+
+    // new API init call
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException {
+      // org.elasticsearch.hadoop.mr.compat.TaskAttemptContext compatContext
+      // = CompatHandler.taskAttemptContext(context);
+      // compatContext.setStatus(split.toString());
+      context.setStatus(split.toString());
+      init((EsInputSplit) split, context.getConfiguration(), context);
+    }
+
+    void init(EsInputSplit esSplit, Configuration cfg, Progressable progressable) {
+      // get a copy to override the host/port
+      Settings settings
+        = HadoopSettingsManager.loadFrom(cfg).copy().load(esSplit.getPartition().getSerializedSettings());
+
+      if (log.isTraceEnabled()) {
+        log.trace(String.format("Init shard reader from cfg %s", HadoopCfgUtils.asProperties(cfg)));
+        log.trace(String.format("Init shard reader w/ settings %s", settings));
+      }
+
+      this.esSplit = esSplit;
+
+      // initialize mapping/ scroll reader
+      InitializationUtils.setValueReaderIfNotSet(settings, WritableValueReader.class, log);
+
+      PartitionDefinition part = esSplit.getPartition();
+      PartitionReader partitionReader = RestService.createReader(settings, part, log);
+
+      this.scrollReader = partitionReader.scrollReader;
+      this.client = partitionReader.client;
+      this.queryBuilder = partitionReader.queryBuilder;
+
+      this.progressable = progressable;
+
+      // in Hadoop-like envs (Spark) the progressable might be null and thus the heart-beat is not needed
+      if (progressable != null) {
+        beat = new HeartBeat(progressable, cfg, settings.getHeartBeatLead(), log);
+      }
+
+      if (log.isDebugEnabled()) {
+        log.debug(String.format("Initializing RecordReader for [%s]", esSplit));
+      }
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException {
+      // new API call routed to old API
+      // under the new API always create new objects since consumers can (and sometimes will) modify them
+
+      currentKey = createKey();
+      currentValue = createValue();
+
+      return next(currentKey, currentValue);
+    }
+
+    @Override
+    public K getCurrentKey() throws IOException {
+      return currentKey;
+    }
+
+    @Override
+    public V getCurrentValue() {
+      return currentValue;
+    }
+
+    @Override
+    public float getProgress() {
+      return size == 0 ? 0 : ((float) getPos()) / size;
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        if (log.isDebugEnabled()) {
+          log.debug(String.format("Closing RecordReader for [%s]", esSplit));
+        }
+
+        if (beat != null) {
+          beat.stop();
+        }
+
+        if (scrollQuery != null) {
+          scrollQuery.close();
+        }
+
+        if (client != null) {
+          client.close();
+        }
+
+      } finally {
+        Stats stats = new Stats();
+        if (client != null) {
+          stats.aggregate(client.stats());
+          client = null;
+        }
+        if (scrollQuery != null) {
+          stats.aggregate(scrollQuery.stats());
+          scrollQuery = null;
+        }
+        ReportingUtils.report(progressable, stats);
+      }
+    }
+
+    @Override
+    public boolean next(K key, V value) throws IOException {
+      if (scrollQuery == null) {
+        if (beat != null) {
+          beat.start();
+        }
+
+        scrollQuery = queryBuilder.build(client, scrollReader);
+        size = scrollQuery.getSize();
+
+        if (log.isTraceEnabled()) {
+          log.trace(String.format("Received scroll [%s],  size [%d] for query [%s]", scrollQuery, size, queryBuilder));
+        }
+      }
+
+      boolean hasNext = scrollQuery.hasNext();
+
+      if (!hasNext) {
+        return false;
+      }
+
+      Object[] next = scrollQuery.next();
+
+      // NB: the left assignment is not needed since method override
+      // the writable content however for consistency, they are below
+      currentKey = setCurrentKey(key, next[0]);
+      currentValue = setCurrentValue(value, next[1]);
+
+      // keep on counting
+      read++;
+      return true;
+    }
+
+    @Override
+    public abstract K createKey();
+
+    @Override
+    public abstract V createValue();
+
+    /**
+     * Sets the current key.
+     *
+     * @param hadoopKey hadoop key
+     * @param object the actual value to read
+     * @return returns the key to be used; needed in scenario where the key is immutable (like Pig)
+     */
+    protected abstract K setCurrentKey(K hadoopKey, Object object);
+
+    /**
+     * Sets the current value.
+     *
+     * @param hadoopValue hadoop value
+     * @param object the actual value to read
+     * @return returns the value to be used; needed in scenario where the passed value is immutable (like Pig)
+     */
+    protected abstract V setCurrentValue(V hadoopValue, Object object);
+
+    @Override
+    public long getPos() {
+      return read;
+    }
+  }
+
+  /**
+   *
+   * @param <V>
+   */
+  protected abstract static class AbstractWritableEsInputRecordReader<V> extends EsInputRecordReader<Text, V> {
+
+    public AbstractWritableEsInputRecordReader() {
+      super();
+    }
+
+    public AbstractWritableEsInputRecordReader(org.apache.hadoop.mapred.InputSplit split, Configuration job,
+                                               Reporter reporter) {
+      super(split, job, reporter);
+    }
+
+    @Override
+    public Text createKey() {
+      return new Text();
+    }
+
+    @Override
+    protected Text setCurrentKey(Text hadoopKey, Object object) {
+      if (hadoopKey != null) {
+        hadoopKey.set(object.toString());
+      }
+      return hadoopKey;
+    }
+  }
+
+  /**
+   *
+   */
+  protected static class WritableEsInputRecordReader
+    extends AbstractWritableEsInputRecordReader<Map<Writable, Writable>> {
+
+    private boolean useLinkedMapWritable = true;
+
+    public WritableEsInputRecordReader() {
+      super();
+    }
+
+    public WritableEsInputRecordReader(org.apache.hadoop.mapred.InputSplit split, Configuration job,
+                                       Reporter reporter) {
+      super(split, job, reporter);
+    }
+
+
+    @Override
+    void init(EsInputSplit esSplit, Configuration cfg, Progressable progressable) {
+      useLinkedMapWritable = (!MapWritable.class.getName().equals(HadoopCfgUtils.getMapValueClass(cfg)));
+      super.init(esSplit, cfg, progressable);
+    }
+
+    @Override
+    public Map<Writable, Writable> createValue() {
+      return (useLinkedMapWritable ? new LinkedMapWritable() : new MapWritable());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Map<Writable, Writable> setCurrentValue(Map<Writable, Writable> hadoopValue, Object object) {
+      if (hadoopValue != null) {
+        hadoopValue.clear();
+        Map<Writable, Writable> val = (Map<Writable, Writable>) object;
+        hadoopValue.putAll(val);
+      }
+      return hadoopValue;
+    }
+  }
+
+  /**
+   *
+   */
+  protected static class JsonWritableEsInputRecordReader extends AbstractWritableEsInputRecordReader<Text> {
+
+    public JsonWritableEsInputRecordReader() {
+      super();
+    }
+
+    public JsonWritableEsInputRecordReader(org.apache.hadoop.mapred.InputSplit split, Configuration job,
+                                           Reporter reporter) {
+      super(split, job, reporter);
+    }
+
+    @Override
+    public Text createValue() {
+      return new Text();
+    }
+
+    @Override
+    protected Text setCurrentValue(Text hadoopValue, Object object) {
+      if (hadoopValue != null) {
+        hadoopValue.set(object.toString());
+      }
+      return hadoopValue;
+    }
+  }
+
+  //
+  // new API - just delegates to the Old API
+  //
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException {
+    JobConf conf = HadoopCfgUtils.asJobConf(context.getConfiguration());
+    // NOTE: this method expects a ShardInputSplit to be returned (which implements both the old and the new API).
+    return Arrays.asList((InputSplit[]) getSplits(conf, conf.getNumMapTasks()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public EsInputRecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context) {
+    return (EsInputRecordReader<K, V>) (isOutputAsJson(context.getConfiguration()) ?
+      new JsonWritableEsInputRecordReader() : new WritableEsInputRecordReader());
+  }
+
+
+  //
+  // Old API - if this method is replaced, make sure to return a new/old-API compatible InputSplit
+  //
+
+  // Note: data written to the JobConf will be silently discarded
+  @Override
+  public org.apache.hadoop.mapred.InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+
+    Settings settings = HadoopSettingsManager.loadFrom(job);
+    Collection<PartitionDefinition> partitions = RestService.findPartitions(settings, log);
+    EsInputSplit[] splits = new EsInputSplit[partitions.size()];
+
+    int index = 0;
+    for (PartitionDefinition part : partitions) {
+      splits[index++] = new EsInputSplit(part);
+    }
+    log.info(String.format("Created [%d] splits", splits.length));
+    return splits;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public EsInputRecordReader<K, V> getRecordReader(org.apache.hadoop.mapred.InputSplit split, JobConf job,
+                                                   Reporter reporter) {
+    return (EsInputRecordReader<K, V>) (isOutputAsJson(job) ?
+      new JsonWritableEsInputRecordReader(split, job, reporter)
+      : new WritableEsInputRecordReader(split, job, reporter));
+  }
+
+  protected boolean isOutputAsJson(Configuration cfg) {
+    return new HadoopSettings(cfg).getOutputAsJson();
+  }
+}

--- a/src/main/java/org/elasticsearch/hadoop/mr/EsOutputFormat.java
+++ b/src/main/java/org/elasticsearch/hadoop/mr/EsOutputFormat.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.hadoop.mr;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.TaskID;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.util.Progressable;
+import org.elasticsearch.hadoop.cfg.HadoopSettingsManager;
+import org.elasticsearch.hadoop.cfg.Settings;
+import org.elasticsearch.hadoop.rest.InitializationUtils;
+import org.elasticsearch.hadoop.rest.Resource;
+import org.elasticsearch.hadoop.rest.RestRepository;
+import org.elasticsearch.hadoop.rest.RestService;
+import org.elasticsearch.hadoop.rest.RestService.PartitionWriter;
+import org.elasticsearch.hadoop.serialization.field.MapWritableFieldExtractor;
+import org.elasticsearch.hadoop.util.Assert;
+
+import static org.elasticsearch.hadoop.cfg.ConfigurationOptions.ES_RESOURCE;
+
+import java.io.IOException;
+
+/**
+ * ElasticSearch {@link OutputFormat} (old and new API) for adding data to an index inside ElasticSearch.
+ */
+@SuppressWarnings("rawtypes")
+// since this class implements two generic interfaces, to avoid dealing with 4 types in every declaration,
+// we force raw types...
+public class EsOutputFormat extends OutputFormat implements org.apache.hadoop.mapred.OutputFormat {
+
+  private static Log log = LogFactory.getLog(EsOutputFormat.class);
+  private static final int NO_TASK_ID = -1;
+
+  /**
+   *
+   */
+  public static class EsOutputCommitter extends org.apache.hadoop.mapreduce.OutputCommitter {
+    // don't use mapred.OutputCommitter as it performs mandatory casts to old API resulting in CCE
+    @Override
+    public void setupJob(JobContext jobContext) throws IOException {}
+
+    // compatibility check with Hadoop 0.20.2
+    @Override
+    @Deprecated
+    public void cleanupJob(JobContext jobContext) throws IOException {}
+
+    @Override
+    public void setupTask(TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext taskContext) throws IOException {
+      //no-op
+      return false;
+    }
+
+    @Override
+    public void commitTask(TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+  }
+
+  /**
+   *
+   */
+  public static class EsOldAPIOutputCommitter extends org.apache.hadoop.mapred.OutputCommitter {
+
+    @Override
+    public void setupJob(org.apache.hadoop.mapred.JobContext jobContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    public void setupTask(org.apache.hadoop.mapred.TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    public boolean needsTaskCommit(org.apache.hadoop.mapred.TaskAttemptContext taskContext) throws IOException {
+      //no-op
+      return false;
+    }
+
+    @Override
+    public void commitTask(org.apache.hadoop.mapred.TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    public void abortTask(org.apache.hadoop.mapred.TaskAttemptContext taskContext) throws IOException {
+      //no-op
+    }
+
+    @Override
+    @Deprecated
+    public void cleanupJob(org.apache.hadoop.mapred.JobContext context) throws IOException {
+      // no-op
+      // added for compatibility with hadoop 0.20.x (used by old tools, such as Cascalog)
+    }
+  }
+
+  /**
+   *
+   */
+  protected static class EsRecordWriter extends RecordWriter implements org.apache.hadoop.mapred.RecordWriter {
+
+    protected final Configuration cfg;
+    protected boolean initialized = false;
+
+    protected RestRepository repository;
+    private String uri;
+    private Resource resource;
+
+    private HeartBeat beat;
+    private final Progressable progressable;
+
+    public EsRecordWriter(Configuration cfg, Progressable progressable) {
+      this.cfg = cfg;
+      this.progressable = progressable;
+    }
+
+    @Override
+    public void write(Object key, Object value) throws IOException {
+      if (!initialized) {
+        initialized = true;
+        init();
+      }
+      repository.writeToIndex(value);
+    }
+
+    protected void init() throws IOException {
+      //int instances = detectNumberOfInstances(cfg);
+      int currentInstance = detectCurrentInstance(cfg);
+
+      if (log.isTraceEnabled()) {
+        log.trace(String.format("EsRecordWriter instance [%s] initiating discovery of target shard...",
+                                currentInstance));
+      }
+
+      Settings settings = HadoopSettingsManager.loadFrom(cfg).copy();
+
+      if (log.isTraceEnabled()) {
+        log.trace(String.format("Init shard writer from cfg %s", HadoopCfgUtils.asProperties(cfg)));
+      }
+
+      InitializationUtils.setValueWriterIfNotSet(settings, WritableValueWriter.class, log);
+      InitializationUtils.setBytesConverterIfNeeded(settings, WritableBytesConverter.class, log);
+      InitializationUtils.setFieldExtractorIfNotSet(settings, MapWritableFieldExtractor.class, log);
+
+      PartitionWriter pw = RestService.createWriter(settings, currentInstance, -1, log);
+
+      this.repository = pw.repository;
+
+      if (progressable != null) {
+        this.beat = new HeartBeat(progressable, cfg, settings.getHeartBeatLead(), log);
+        this.beat.start();
+      }
+    }
+
+    private int detectCurrentInstance(Configuration conf) {
+      TaskID taskID = HadoopCfgUtils.getTaskID(conf);
+
+      if (taskID == null) {
+        log.warn(String.format("Cannot determine task id - redirecting writes in a random fashion"));
+        return NO_TASK_ID;
+      }
+
+      return taskID.getId();
+    }
+
+    @Override
+    public void close(TaskAttemptContext context) throws IOException {
+      doClose(context);
+    }
+
+    @Override
+    public void close(Reporter reporter) throws IOException {
+      doClose(reporter);
+    }
+
+    protected void doClose(Progressable progressable) {
+      if (log.isTraceEnabled()) {
+        log.trace(String.format("Closing RecordWriter [%s][%s]", uri, resource));
+      }
+
+      if (beat != null) {
+        beat.stop();
+      }
+
+      if (repository != null) {
+        repository.close();
+        ReportingUtils.report(progressable, repository.stats());
+      }
+
+      initialized = false;
+    }
+  }
+
+  //
+  // new API - just delegates to the Old API
+  //
+  @Override
+  public org.apache.hadoop.mapreduce.RecordWriter getRecordWriter(TaskAttemptContext context) {
+    return (org.apache.hadoop.mapreduce.RecordWriter)
+      getRecordWriter(null, HadoopCfgUtils.asJobConf(context.getConfiguration()), null, context);
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext context) throws IOException {
+    // careful as it seems the info here saved by in the config is discarded
+    init(context.getConfiguration());
+  }
+
+  @Override
+  public org.apache.hadoop.mapreduce.OutputCommitter getOutputCommitter(TaskAttemptContext context) {
+    return new EsOutputCommitter();
+  }
+
+  //
+  // old API
+  //
+  @Override
+  public org.apache.hadoop.mapred.RecordWriter getRecordWriter(FileSystem ignored, JobConf job, String name,
+                                                               Progressable progress) {
+    return new EsRecordWriter(job, progress);
+  }
+
+  @Override
+  public void checkOutputSpecs(FileSystem ignored, JobConf cfg) throws IOException {
+    init(cfg);
+  }
+
+  // NB: all changes to the config objects are discarded before the job is submitted if _the old MR api_ is used
+  private void init(Configuration cfg) throws IOException {
+    Settings settings = HadoopSettingsManager.loadFrom(cfg);
+    Assert.hasText(settings.getResourceWrite(), String.format("No resource ['%s'] (index/query/location) specified",
+                                                              ES_RESOURCE));
+
+    InitializationUtils.checkIdForOperation(settings);
+    InitializationUtils.checkIndexExistence(settings);
+
+    if (HadoopCfgUtils.getReduceTasks(cfg) != null) {
+      if (HadoopCfgUtils.getSpeculativeReduce(cfg)) {
+        log.warn("Speculative execution enabled for reducer - consider disabling it to prevent data corruption");
+      }
+    } else {
+      if (HadoopCfgUtils.getSpeculativeMap(cfg)) {
+        log.warn("Speculative execution enabled for mapper - consider disabling it to prevent data corruption");
+      }
+    }
+
+    //log.info(String.format("Starting to write/index to [%s][%s]", settings.getTargetUri(),
+    // settings.getTargetResource()));
+  }
+}


### PR DESCRIPTION
…nd updated methods to remove CompatHandler(which uses reflection) but rather directly use the contexts classes provided.

EsInputFormat class is from here - https://github.com/elastic/elasticsearch-hadoop/blob/v5.4.0/mr/src/main/java/org/elasticsearch/hadoop/mr/EsInputFormat.java

EsOutputFormat class is from here - https://github.com/elastic/elasticsearch-hadoop/blob/v5.4.0/mr/src/main/java/org/elasticsearch/hadoop/mr/EsOutputFormat.java